### PR TITLE
Adjusted progress bar chunk width in transfer-progress-dialog.

### DIFF
--- a/src/ui/transfer-progress-dialog.cpp
+++ b/src/ui/transfer-progress-dialog.cpp
@@ -37,7 +37,7 @@ const QColor kItemBottomBorderColor("#f3f3f3");
 const QColor kItemColor("black");
 const QString kProgressBarStyle("QProgressBar "
         "{ border: 1px solid grey; border-radius: 2px; } "
-        "QProgressBar::chunk { background-color: #f0f0f0; width: 20px; }");
+        "QProgressBar::chunk { background-color: #f0f0f0; width: 1px; }");
 
 QString normalizedPath(const QString& file_path)
 {


### PR DESCRIPTION
![progress-bar-chunk-width](https://user-images.githubusercontent.com/8081131/27381516-b43ef0e0-56b5-11e7-9def-518261c58436.PNG)
