### PR TITLE
Removed a stretchable space in TransferTab layout.

### DIFF
--- a/src/ui/transfer-progress-dialog.cpp
+++ b/src/ui/transfer-progress-dialog.cpp
@@ -62,7 +62,7 @@ TransferProgressDialog::TransferProgressDialog(QWidget *parent)
     setWindowFlags((windowFlags() & ~Qt::WindowContextHelpButtonHint) |
                    Qt::WindowStaysOnTopHint);
 
-    setMinimumSize(QSize(500, 200));
+    setMinimumSize(QSize(600, 371));
 
     QVBoxLayout* vlayout = new QVBoxLayout;
     vlayout->setContentsMargins(0, 0, 0, 0);
@@ -92,7 +92,6 @@ TransferTab::TransferTab(TransferType type, QWidget *parent)
     QVBoxLayout* vlayout = new QVBoxLayout;
     createTable(type);
     vlayout->addWidget(table_);
-    vlayout->addStretch(1);
     setLayout(vlayout);
     adjustSize();
 }


### PR DESCRIPTION
![default](https://user-images.githubusercontent.com/8081131/32700062-419f7224-c7fa-11e7-9c23-fba4fe86b80a.PNG)
