### PR TITLE
Fix compilation errors with glib2 >= 2.67.3

### DIFF
--- a/src/daemon-mgr.cpp
+++ b/src/daemon-mgr.cpp
@@ -1,7 +1,5 @@
-extern "C" {
 #include <searpc-client.h>
 #include <searpc-named-pipe-transport.h>
-}
 
 #if defined(_MSC_VER)
 #include <windows.h>

--- a/src/rpc/rpc-client.cpp
+++ b/src/rpc/rpc-client.cpp
@@ -1,9 +1,5 @@
-extern "C" {
-
 #include <searpc-client.h>
 #include <searpc-named-pipe-transport.h>
-
-}
 
 #include <QtDebug>
 #include <QMutexLocker>

--- a/src/rpc/rpc-server.cpp
+++ b/src/rpc/rpc-server.cpp
@@ -1,9 +1,9 @@
-extern "C" {
-
 #include <searpc.h>
 #include <searpc-client.h>
 #include <searpc-server.h>
 #include <searpc-named-pipe-transport.h>
+
+extern "C" {
 
 #include "searpc-signature.h"
 #include "searpc-marshal.h"


### PR DESCRIPTION
See https://github.com/haiwen/seafile-client/pull/1346 for details.

Depends on: https://github.com/haiwen/libsearpc/pull/57 (would fail to link without that change)

