### PR TITLE
Fix QCryptographicHash include

### DIFF
--- a/src/seadrive-gui.cpp
+++ b/src/seadrive-gui.cpp
@@ -9,7 +9,7 @@
 #include <QCoreApplication>
 #include <QMessageBox>
 #include <QHostInfo>
-#include <QCryptoGraphicHash>
+#include <QCryptographicHash>
 
 #include <errno.h>
 #include <glib.h>


### PR DESCRIPTION
AFAICT this has always been using the wrong case but before 0412f9b99f3ba355e1e3462c8f6a92bd7565fa76 it was only enabled on windows where the case mismatch matters less.