### PR TITLE
Auto-resolve network sync errors once the server is reachable again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ SET(moc_headers
   src/network-mgr.h
   src/remote-wipe-service.h
   src/account-info-service.h
+  src/server-connectivity-service.h
   src/rpc/rpc-client.h
   src/rpc/rpc-server.h
   src/seadrive-gui.h
@@ -295,6 +296,7 @@ SET(seadrive_gui_sources
   src/network-mgr.cpp
   src/remote-wipe-service.cpp
   src/account-info-service.cpp
+  src/server-connectivity-service.cpp
 
   src/rpc/rpc-client.cpp
   src/rpc/rpc-server.cpp

--- a/seadrive-gui.vcxproj
+++ b/seadrive-gui.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\account-info-service.cpp" />
+    <ClCompile Include="src\server-connectivity-service.cpp" />
     <ClCompile Include="src\account-mgr.cpp" />
     <ClCompile Include="src\account.cpp" />
     <ClCompile Include="src\api\api-client.cpp" />
@@ -120,6 +121,7 @@
     <QtMoc Include="src\auto-login-service.h" />
     <QtMoc Include="src\account-mgr.h" />
     <QtMoc Include="src\account-info-service.h" />
+    <QtMoc Include="src\server-connectivity-service.h" />
     <ClInclude Include="src\account.h" />
     <ClInclude Include="src\api\api-error.h" />
     <ClInclude Include="src\api\commit-details.h" />

--- a/seadrive-gui.vcxproj.filters
+++ b/seadrive-gui.vcxproj.filters
@@ -79,6 +79,9 @@
     <ClCompile Include="src\account-info-service.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\server-connectivity-service.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\account-mgr.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -441,6 +444,9 @@
       <Filter>third_party\QtAwesome</Filter>
     </QtMoc>
     <QtMoc Include="src\account-info-service.h">
+      <Filter>Header Files</Filter>
+    </QtMoc>
+    <QtMoc Include="src\server-connectivity-service.h">
       <Filter>Header Files</Filter>
     </QtMoc>
     <QtMoc Include="src\account-mgr.h">

--- a/src/api/api-client.cpp
+++ b/src/api/api-client.cpp
@@ -11,6 +11,7 @@
 // #include "ui/ssl-confirm-dialog.h"
 #include "utils/utils.h"
 #include "network-mgr.h"
+#include "server-connectivity-service.h"
 
 #include "api-client.h"
 
@@ -233,6 +234,8 @@ void SeafileApiClient::httpRequestFinished()
         emit networkError(reply_->error(), reply_->errorString());
         return;
     }
+
+    ServerConnectivityService::instance()->updateOnSuccessfulRequest(reply_->url());
 
     if (handleHttpRedirect()) {
         return;

--- a/src/seadrive-gui.cpp
+++ b/src/seadrive-gui.cpp
@@ -711,6 +711,9 @@ void SeadriveGui::connectDaemon()
                 message_poller->stop();
                 delete message_poller;
             }
+            // The poller is gone, so clear the domain's sync errors it
+            // would otherwise leave displayed forever.
+            tray_icon_->setSyncErrors(domain_id, QList<SyncError>());
             rpc_clients_.remove(domain_id);
             delete rpc_client;
             init_sync_dlg_->clearPoller(domain_id);

--- a/src/server-connectivity-service.cpp
+++ b/src/server-connectivity-service.cpp
@@ -1,0 +1,68 @@
+#include <QDateTime>
+
+#include "server-connectivity-service.h"
+#include "api/api-error.h"
+#include "api/requests.h"
+
+namespace {
+
+const int kMinCheckIntervalMSecs = 10 * 1000;
+
+} // namespace
+
+SINGLETON_IMPL(ServerConnectivityService)
+
+ServerConnectivityService::ServerConnectivityService(QObject *parent)
+    : QObject(parent)
+{
+}
+
+qint64 ServerConnectivityService::lastSuccessTime(const QString& host) const
+{
+    return last_success_.value(host, 0);
+}
+
+void ServerConnectivityService::checkServer(const QUrl& url)
+{
+    const QString host = url.host();
+    if (host.isEmpty() || requests_.contains(host)) {
+        return;
+    }
+
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if (now - last_attempt_.value(host, 0) < kMinCheckIntervalMSecs) {
+        return;
+    }
+    last_attempt_[host] = now;
+
+    PingServerRequest *req = new PingServerRequest(url);
+    connect(req, SIGNAL(success()),
+            this, SLOT(onPingServerSuccess()));
+    connect(req, SIGNAL(failed(const ApiError&)),
+            this, SLOT(onPingServerFailed()));
+    req->send();
+    requests_[host] = req;
+}
+
+void ServerConnectivityService::updateOnSuccessfulRequest(const QUrl& url)
+{
+    if (url.host().isEmpty()) {
+        return;
+    }
+    last_success_[url.host()] = QDateTime::currentMSecsSinceEpoch() / 1000;
+}
+
+void ServerConnectivityService::onPingServerSuccess()
+{
+    PingServerRequest *req = (PingServerRequest *)sender();
+    last_success_[req->url().host()] = QDateTime::currentMSecsSinceEpoch() / 1000;
+    requests_.remove(req->url().host());
+    req->deleteLater();
+}
+
+void ServerConnectivityService::onPingServerFailed()
+{
+    PingServerRequest *req = (PingServerRequest *)sender();
+    requests_.remove(req->url().host());
+    req->deleteLater();
+}

--- a/src/server-connectivity-service.h
+++ b/src/server-connectivity-service.h
@@ -1,0 +1,51 @@
+#ifndef SEADRIVE_GUI_SERVER_CONNECTIVITY_SERVICE_H
+#define SEADRIVE_GUI_SERVER_CONNECTIVITY_SERVICE_H
+
+#include <QObject>
+#include <QUrl>
+#include <QHash>
+
+#include "utils/singleton.h"
+
+class PingServerRequest;
+class ApiError;
+
+/**
+ * Tracks when each server was last successfully contacted, so that
+ * network errors reported by the daemon can be treated as resolved once
+ * the server is reachable again.
+ *
+ * The last-success time is updated passively by successful API requests
+ * (see SeafileApiClient), and actively by checkServer(), which the tray
+ * icon calls while a network error is being displayed.
+ */
+class ServerConnectivityService : public QObject
+{
+    Q_OBJECT
+    SINGLETON_DEFINE(ServerConnectivityService)
+public:
+    // Seconds since epoch of the last successful contact with the
+    // server, or 0 if it has not been contacted successfully yet.
+    qint64 lastSuccessTime(const QString& host) const;
+
+    // Ping the server unless a check is already in flight or one was
+    // attempted recently.
+    void checkServer(const QUrl& url);
+
+public slots:
+    void updateOnSuccessfulRequest(const QUrl& url);
+
+private slots:
+    void onPingServerSuccess();
+    void onPingServerFailed();
+
+private:
+    Q_DISABLE_COPY(ServerConnectivityService)
+    ServerConnectivityService(QObject *parent=0);
+
+    QHash<QString, qint64> last_success_;
+    QHash<QString, qint64> last_attempt_;
+    QHash<QString, PingServerRequest *> requests_;
+};
+
+#endif // SEADRIVE_GUI_SERVER_CONNECTIVITY_SERVICE_H

--- a/src/ui/tray-icon.cpp
+++ b/src/ui/tray-icon.cpp
@@ -29,6 +29,7 @@
 #include "rpc/rpc-client.h"
 #include "file-provider-mgr.h"
 #include "settings-mgr.h"
+#include "server-connectivity-service.h"
 
 #include "tray-icon.h"
 
@@ -789,19 +790,20 @@ void SeafileTrayIcon::setTransferRate(qint64 up_rate, qint64 down_rate)
 void SeafileTrayIcon::setSyncErrors(const QString& domain_id, const QList<SyncError> errors)
 {
     sync_errors_.clear();
-    raw_network_errors_.clear();
 
     QList<SyncError> sync_errors;
+    QList<SyncError> network_errors;
 
     foreach (const SyncError& error, errors) {
         if (error.isNetworkError()) {
-            raw_network_errors_.push_back(error);
+            network_errors.push_back(error);
         } else {
             sync_errors.push_back(error);
         }
     }
 
     domain_errors_.insert(domain_id, sync_errors);
+    domain_network_errors_.insert(domain_id, network_errors);
 
     QMapIterator<QString, QList<SyncError>> it(domain_errors_);
     while (it.hasNext()) {
@@ -810,18 +812,61 @@ void SeafileTrayIcon::setSyncErrors(const QString& domain_id, const QList<SyncEr
         sync_errors_.append(error);
     }
 
-    network_errors_.clear();
-    QMap<QString, SyncError> latest_network_errors_by_server;
-    for (const SyncError& error : raw_network_errors_) {
-        const QString& server_key = error.server;
-        if (!latest_network_errors_by_server.contains(server_key) ||
-            latest_network_errors_by_server.value(server_key).timestamp < error.timestamp) {
-            latest_network_errors_by_server.insert(server_key, error);
-        }
-    }
-    network_errors_ = latest_network_errors_by_server.values();
+    updateNetworkErrors();
 
     reloadTrayIcon();
+}
+
+namespace {
+
+// The daemon reports the server of a sync error as a plain url string.
+// Prefer the matching account's server url for pinging, since it is
+// normalized (scheme, port).
+QUrl serverUrlForSyncError(const SyncError& error)
+{
+    QUrl url(error.server);
+    const auto accounts = gui->accountManager()->activeAccounts();
+    for (const Account& account : accounts) {
+        if (account.serverUrl.host() == url.host()) {
+            return account.serverUrl;
+        }
+    }
+    return url;
+}
+
+} // namespace
+
+void SeafileTrayIcon::updateNetworkErrors()
+{
+    // Keep only the latest network error per server, and drop the
+    // errors of servers that have been successfully contacted since the
+    // error happened: network errors are transient, so once the server
+    // is reachable again they are resolved and should not keep the tray
+    // icon in the error state.
+    QMap<QString, SyncError> latest_network_errors_by_server;
+    QMapIterator<QString, QList<SyncError>> it(domain_network_errors_);
+    while (it.hasNext()) {
+        it.next();
+        for (const SyncError& error : it.value()) {
+            const QString& server_key = error.server;
+            if (!latest_network_errors_by_server.contains(server_key) ||
+                latest_network_errors_by_server.value(server_key).timestamp < error.timestamp) {
+                latest_network_errors_by_server.insert(server_key, error);
+            }
+        }
+    }
+
+    network_errors_.clear();
+    for (const SyncError& error : latest_network_errors_by_server.values()) {
+        QUrl url = serverUrlForSyncError(error);
+        if (ServerConnectivityService::instance()->lastSuccessTime(url.host()) > error.timestamp) {
+            continue;
+        }
+        network_errors_.push_back(error);
+        // Keep probing the server while its error is displayed; a
+        // successful ping resolves the error on the next update.
+        ServerConnectivityService::instance()->checkServer(url);
+    }
 }
 
 void SeafileTrayIcon::setStateWithSyncErrors()

--- a/src/ui/tray-icon.h
+++ b/src/ui/tray-icon.h
@@ -105,6 +105,7 @@ private:
     void createContextMenu();
     void createGlobalMenuBar();
     void setStateWithSyncErrors();
+    void updateNetworkErrors();
 
     QIcon stateToIcon(TrayState state);
     QIcon getIcon(const QString& name);
@@ -171,7 +172,7 @@ private:
 
     QList<SyncError> sync_errors_;
     QMap<QString, QList<SyncError>> domain_errors_;
-    QList<SyncError> raw_network_errors_;
+    QMap<QString, QList<SyncError>> domain_network_errors_;
     QList<SyncError> network_errors_;
     SyncErrorsDialog *sync_errors_dialog_;
     TransferProgressDialog * transfer_progress_dialog_;


### PR DESCRIPTION
When the connection dropped or the server went offline, the daemon kept reporting the network errors and the tray icon stayed in the error state indefinitely, even after connectivity was restored.

Treat network errors as transient: track when each server was last successfully contacted (via a new ServerConnectivityService), and drop a network error once its server has been contacted after the error happened. While a network error is displayed, the affected server is pinged periodically, so the error resolves itself shortly after the server is reachable again. Successful API requests also count as contact, so normal traffic clears the state too.

Additionally, network errors are now kept per account domain instead of a single list that each account's message poller overwrote every second, which previously dropped other accounts' network errors.