### PR TITLE
Simplify the drive name shown in the Explorer sidebar

### DIFF
--- a/src/account-mgr.cpp
+++ b/src/account-mgr.cpp
@@ -7,6 +7,7 @@
 #include <QDateTime>
 #include <QMutexLocker>
 #include <QRegularExpression>
+#include <QTimer>
 
 #include "account-mgr.h"
 #include "rpc/rpc-client.h"
@@ -24,6 +25,7 @@
 
 #ifdef Q_OS_WIN32
 #include "utils/file-utils.h"
+#include "utils/registry.h"
 #include "win-sso/auto-logon-dialog.h"
 #endif
 
@@ -360,6 +362,11 @@ int AccountManager::removeAccount(const Account& account)
     SeafileRpcClient *rpc_client = gui->rpcClient(EMPTY_DOMAIN_ID);
     if (rpc_client) {
         rpc_client->deleteAccount(account, false);
+#if defined(Q_OS_WIN32)
+        // The remaining account (if it is now the only one) loses its
+        // account suffix in the explorer sidebar.
+        scheduleUpdateSyncRootSidebarLabels();
+#endif
     }
 #endif
 
@@ -595,6 +602,9 @@ void AccountManager::addAccountToDaemon(const Account& account)
     SeafileRpcClient *rpc_client = gui->rpcClient(EMPTY_DOMAIN_ID);
     if (rpc_client) {
         rpc_client->addAccount(added_account);
+#if defined(Q_OS_WIN32)
+        scheduleUpdateSyncRootSidebarLabels();
+#endif
     }
 #endif
 }
@@ -948,6 +958,52 @@ void AccountManager::setAccountSyncRoot(Account &account)
             accounts_[i].syncRoot = sync_root;
             break;
         }
+    }
+}
+
+// The daemon registers each sync root in Explorer's navigation pane as
+// "SeaDrive - <user> (<server>)". When only one sync root is registered that
+// suffix carries no information, so relabel the entry to the plain brand
+// name; with multiple sync roots keep the account suffix to tell them apart.
+void AccountManager::updateSyncRootSidebarLabels()
+{
+    QStringList sync_root_ids = RegElement::collectSyncRootManagerIds();
+    if (sync_root_ids.isEmpty()) {
+        return;
+    }
+
+    auto accounts = activeAccounts();
+    for (int i = 0; i < accounts.size(); i++) {
+        const Account& account = accounts.at(i);
+
+        QString serverAddr = account.serverUrl.toString(QUrl::FullyEncoded);
+        if (serverAddr.endsWith("/")) {
+            serverAddr = serverAddr.left(serverAddr.size() - 1);
+        }
+        QString sync_root_id = QString("seadrive!%1!%2").arg(serverAddr).arg(account.username);
+        // Registry key names are case insensitive.
+        if (!sync_root_ids.contains(sync_root_id, Qt::CaseInsensitive)) {
+            continue;
+        }
+
+        QString label = getBrand();
+        if (sync_root_ids.size() > 1) {
+            label += " - " + getDisplayName(account);
+        }
+        RegElement::setSyncRootSidebarLabel(sync_root_id, label);
+    }
+}
+
+// The sync root is registered by the daemon at some point after the
+// seafile_add_account rpc returns, so the label rewrite is retried a few
+// times instead of being attempted only once.
+void AccountManager::scheduleUpdateSyncRootSidebarLabels()
+{
+    updateSyncRootSidebarLabels();
+
+    const int delays[] = {2000, 10000, 30000};
+    for (int delay : delays) {
+        QTimer::singleShot(delay, this, [this]() { updateSyncRootSidebarLabels(); });
     }
 }
 #endif

--- a/src/account-mgr.h
+++ b/src/account-mgr.h
@@ -105,6 +105,7 @@ public:
     QString getPreviousSyncRootName(const Account& account);
     const QString genSyncRootName(const Account& account);
     void setSyncRootName(const Account& account, const QString& custom_name);
+    void scheduleUpdateSyncRootSidebarLabels();
 #endif
 
 public slots:
@@ -144,6 +145,7 @@ private:
 #ifdef Q_OS_WIN32
     static bool loadSyncRootInfoCB(struct sqlite3_stmt *stmt, void *data);
     void loadSyncRootInfo();
+    void updateSyncRootSidebarLabels();
     void updateSyncRootInfo(SyncRootInfo& sync_root_info);
     const QString getOldSyncRootDir(const Account& account);
     void setAccountSyncRoot(Account &account);

--- a/src/rpc/rpc-client.cpp
+++ b/src/rpc/rpc-client.cpp
@@ -581,7 +581,7 @@ QString getDisplayName (const Account account) {
     if (name.isEmpty()) {
         name = account.username;
     }
-    return name + "(" + account.serverUrl.host() + ")";
+    return name + " (" + account.serverUrl.host() + ")";
 }
 
 bool SeafileRpcClient::addAccount(const Account& account)

--- a/src/rpc/rpc-client.h
+++ b/src/rpc/rpc-client.h
@@ -26,6 +26,10 @@ class AccountManager;
 #endif
 class CommitDetails;
 
+#if defined(Q_OS_WIN32)
+QString getDisplayName(const Account account);
+#endif
+
 class SeafileRpcClient : public QObject {
     Q_OBJECT
 

--- a/src/seadrive-gui.cpp
+++ b/src/seadrive-gui.cpp
@@ -565,6 +565,9 @@ void SeadriveGui::onDaemonStarted()
         auto account = accounts.at(i);
         rpc_client->addAccount(account);
     }
+#if defined(Q_OS_WIN32)
+    account_mgr_->scheduleUpdateSyncRootSidebarLabels();
+#endif
 
     tray_icon_->start();
     settings_mgr_->writeSettingsToDaemon();
@@ -613,6 +616,9 @@ void SeadriveGui::onDaemonRestarted()
     for (int i = 0; i <  accounts.size(); i++) {
         rpc_client->addAccount(accounts.at(i));
     }
+#if defined(Q_OS_WIN32)
+    account_mgr_->scheduleUpdateSyncRootSidebarLabels();
+#endif
     MessagePoller *message_poller = messagePoller(EMPTY_DOMAIN_ID);
     if (message_poller) {
         message_poller->setRpcClient (rpc_client);

--- a/src/utils/registry.cpp
+++ b/src/utils/registry.cpp
@@ -1,5 +1,6 @@
 #include <windows.h>
 #include <shlwapi.h>
+#include <shlobj.h>
 #include <vector>
 
 #include <QCoreApplication>
@@ -402,6 +403,48 @@ void RegElement::removeAllSyncRootManagerItem()
     }
     return;
 
+}
+
+QStringList RegElement::collectSyncRootManagerIds()
+{
+    return collectSyncRootMangerKeys(HKEY_LOCAL_MACHINE,
+                                     QString::fromWCharArray(kSYNC_ROOT_MANAGER));
+}
+
+// The label Explorer shows for a sync root in the navigation pane comes from
+// the default value of HKCU\Software\Classes\CLSID\<NamespaceCLSID>, not from
+// the SyncRootManager entry itself. The latter lives under HKLM and cannot be
+// written without elevation, but the CLSID key is per-user, so the label can
+// be overridden there.
+bool RegElement::setSyncRootSidebarLabel(const QString& sync_root_id, const QString& label)
+{
+    QString sync_root_path = QString::fromWCharArray(kSYNC_ROOT_MANAGER) + "\\" + sync_root_id;
+    QString clsid = getStringValue(HKEY_LOCAL_MACHINE, sync_root_path, "NamespaceCLSID");
+    if (clsid.isEmpty()) {
+        // The daemon has not registered this sync root yet.
+        return false;
+    }
+
+    QString clsid_path = QString("Software\\Classes\\CLSID\\%1").arg(clsid);
+    HKEY clsid_key;
+    if (openKey(HKEY_CURRENT_USER, clsid_path, &clsid_key, KEY_READ) != ERROR_SUCCESS) {
+        return false;
+    }
+    RegCloseKey(clsid_key);
+
+    if (getStringValue(HKEY_CURRENT_USER, clsid_path, "") == label) {
+        return true;
+    }
+
+    RegElement reg(HKEY_CURRENT_USER, clsid_path, "", label);
+    if (reg.add() != 0) {
+        qWarning("failed to set the sidebar label of sync root %s",
+                 sync_root_id.toUtf8().data());
+        return false;
+    }
+
+    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, NULL, NULL);
+    return true;
 }
 
 #endif

--- a/src/utils/registry.h
+++ b/src/utils/registry.h
@@ -2,6 +2,7 @@
 #define SEAFILE_CLIENT_UTILS_REGISTRY_H
 
 #include <QString>
+#include <QStringList>
 #include <QVariant>
 #include <windows.h>
 
@@ -55,6 +56,8 @@ public:
     static QVariant getPreconfigureValue(const QString& name);
     static QVariant getValue(HKEY root, const QString& path, const QString& name);
     static void removeAllSyncRootManagerItem();
+    static QStringList collectSyncRootManagerIds();
+    static bool setSyncRootSidebarLabel(const QString& sync_root_id, const QString& label);
     static void installCustomUrlHandler();
 
 private:


### PR DESCRIPTION
## What this does

The sync root currently appears in the Explorer navigation pane as `SeaDrive - Ryan Ewen(seafile.example.com)`. Two changes:

1. **Missing space**: `getDisplayName()` now returns `Name (host)` instead of `Name(host)`, so the registered label reads `SeaDrive - Ryan Ewen (seafile.example.com)`.
2. **Drop the account suffix when it carries no information**: when only one sync root is registered, the sidebar entry is relabeled to just **`SeaDrive`**. With two or more accounts, each entry keeps its full `SeaDrive - Name (host)` label so they can be told apart. Labels self-correct when accounts are added or removed.

## Note: this contains a workaround for daemon behavior

The seadrive daemon always registers the sync root as `SeaDrive - <display name>`, where only `<display name>` comes from the GUI (via `seafile_add_account`). There is no way to get a plain `SeaDrive` label through the RPC alone — passing an empty display name would presumably leave a dangling `SeaDrive - `.

So the single-account case is handled by rewriting the label **after** the daemon registers it: Explorer reads the sidebar label from the default value of `HKCU\Software\Classes\CLSID\<NamespaceCLSID>` (per-user writable, unlike the `SyncRootManager` entry under HKLM), and the new `RegElement::setSyncRootSidebarLabel()` overwrites that value. Because the daemon registers sync roots asynchronously after the RPC returns, the rewrite is retried a few times (2s/10s/30s) after accounts are added/removed and on every daemon start.

**If the daemon were changed to use the GUI-provided display name verbatim** (i.e. not force the `"SeaDrive - "` prefix, letting the GUI pass `SeaDrive` or `SeaDrive - Name (host)` as the full label), the registry rewrite, the retry timers, and `AccountManager::updateSyncRootSidebarLabels()` could all be deleted — the GUI would simply pass the right label in `seafile_add_account`.

## Changes

- `src/rpc/rpc-client.cpp`: space fix in `getDisplayName()`, now also declared in the header for reuse
- `src/utils/registry.{h,cpp}`: `collectSyncRootManagerIds()` and `setSyncRootSidebarLabel()` helpers
- `src/account-mgr.{h,cpp}`: `updateSyncRootSidebarLabels()` computes the desired label per account; scheduled with retries from account add/remove
- `src/seadrive-gui.cpp`: labels refreshed on daemon start/restart
